### PR TITLE
Replace Qt defines for Windows as Q_OS_WIN is never defined

### DIFF
--- a/core/fxcrt/fx_basic_util.cpp
+++ b/core/fxcrt/fx_basic_util.cpp
@@ -127,7 +127,7 @@ FX_FLOAT FX_atof(const CFX_ByteStringC& strc) {
   return bNegative ? -value : value;
 }
 
-#if (_FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && defined(Q_CC_MSVC))) && _MSC_VER < 1900
+#if (_FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && (_WIN32 || _WIN64))) && _MSC_VER < 1900
 void FXSYS_snprintf(char* str,
                     size_t size,
                     _Printf_format_string_ const char* fmt,
@@ -143,10 +143,10 @@ void FXSYS_vsnprintf(char* str, size_t size, const char* fmt, va_list ap) {
   if (size)
     str[size - 1] = 0;
 }
-#endif  // (_FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && defined(Q_CC_MSVC))) && _MSC_VER < 1900
+#endif  // (_FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && (_WIN32 || _WIN64)) && _MSC_VER < 1900
 
 FX_FileHandle* FX_OpenFolder(const FX_CHAR* path) {
-#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && defined(Q_OS_WIN))
+#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && (_WIN32 || _WIN64))
   std::unique_ptr<CFindFileDataA> pData(new CFindFileDataA);
   pData->m_Handle = FindFirstFileExA((CFX_ByteString(path) + "/*.*").c_str(),
                                      FindExInfoStandard, &pData->m_FindData,
@@ -167,7 +167,7 @@ bool FX_GetNextFile(FX_FileHandle* handle,
   if (!handle)
     return false;
 
-#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && defined(Q_OS_WIN))
+#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && (_WIN32 || _WIN64))
   if (handle->m_bEnd)
     return false;
 
@@ -194,7 +194,7 @@ void FX_CloseFolder(FX_FileHandle* handle) {
   if (!handle)
     return;
 
-#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && defined(Q_OS_WIN))
+#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && (_WIN32 || _WIN64))
   FindClose(handle->m_Handle);
   delete handle;
 #else
@@ -203,7 +203,7 @@ void FX_CloseFolder(FX_FileHandle* handle) {
 }
 
 FX_WCHAR FX_GetFolderSeparator() {
-#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && defined(Q_OS_WIN))
+#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && (_WIN32 || _WIN64))
   return '\\';
 #else
   return '/';

--- a/core/fxcrt/fx_stream.h
+++ b/core/fxcrt/fx_stream.h
@@ -11,7 +11,7 @@
 #include "core/fxcrt/fx_string.h"
 #include "core/fxcrt/fx_system.h"
 
-#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && defined(Q_OS_WIN))
+#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && (_WIN32 || _WIN64))
 #include <direct.h>
 
 class CFindFileDataA;
@@ -36,7 +36,7 @@ typedef CFindFileDataA FX_FileHandle;
 
 typedef DIR FX_FileHandle;
 #define FX_FILESIZE off_t
-#endif  // _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && defined(Q_OS_WIN))
+#endif  // _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && (_WIN32 || _WIN64))
 
 FX_FileHandle* FX_OpenFolder(const FX_CHAR* path);
 bool FX_GetNextFile(FX_FileHandle* handle,
@@ -154,7 +154,7 @@ class IFX_FileAccess : public CFX_Retainable {
 };
 #endif  // PDF_ENABLE_XFA
 
-#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && defined(Q_OS_WIN))
+#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && (_WIN32 || _WIN64))
 class CFindFileData {
  public:
   virtual ~CFindFileData() {}

--- a/core/fxcrt/fx_system.h
+++ b/core/fxcrt/fx_system.h
@@ -58,7 +58,7 @@
 #error Sorry, can not figure out target OS. Please specify _FX_OS_ macro.
 #endif
 
-#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_
+#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && (_WIN32 || _WIN64))
 #include <windows.h>
 #include <sal.h>
 #endif
@@ -325,7 +325,7 @@ int FXSYS_round(FX_FLOAT f);
 
 // Prevent a function from ever being inlined, typically because we'd
 // like it to appear in stack traces.
-#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && defined(Q_CC_MSVC))
+#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && (_WIN32 || _WIN64))
 #define NEVER_INLINE __declspec(noinline)
 #else  // _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_
 #define NEVER_INLINE __attribute__((__noinline__))

--- a/core/fxge/cfx_windowsdevice.h
+++ b/core/fxge/cfx_windowsdevice.h
@@ -7,7 +7,7 @@
 #ifndef CORE_FXGE_CFX_WINDOWSDEVICE_H_
 #define CORE_FXGE_CFX_WINDOWSDEVICE_H_
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__QT__)
 #ifndef _WINDOWS_
 #include <windows.h>
 #endif
@@ -37,6 +37,6 @@ class CFX_WindowsDevice : public CFX_RenderDevice {
   HDC GetDC() const;
 };
 
-#endif  // _WIN32
+#endif  //defined(_WIN32) && !defined(__QT__)
 
 #endif  // CORE_FXGE_CFX_WINDOWSDEVICE_H_

--- a/fpdfsdk/fpdfview.cpp
+++ b/fpdfsdk/fpdfview.cpp
@@ -44,7 +44,7 @@
 #include "xfa/fxbarcode/BC_Library.h"
 #endif  // PDF_ENABLE_XFA
 
-#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_
+#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_ || (_FXM_PLATFORM_ == _FXM_PLATFORM_QT_ && (_WIN32 || _WIN64))
 #include "core/fxge/cfx_windowsdevice.h"
 #endif
 
@@ -429,7 +429,7 @@ DLLEXPORT void STDCALL FPDF_SetSandBoxPolicy(FPDF_DWORD policy,
   return FSDK_SetSandBoxPolicy(policy, enable);
 }
 
-#if defined(_WIN32) && !defined(Q_OS_WIN)
+#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_
 #if defined(PDFIUM_PRINT_TEXT_WITH_GDI)
 DLLEXPORT void STDCALL
 FPDF_SetTypefaceAccessibleFunc(PDFiumEnsureTypefaceCharactersAccessible func) {
@@ -648,7 +648,7 @@ DLLEXPORT double STDCALL FPDF_GetPageHeight(FPDF_PAGE page) {
   return pPage ? pPage->GetPageHeight() : 0.0;
 }
 
-#if (defined(_WIN32) && !defined(Q_OS_WIN))
+#if _FXM_PLATFORM_ == _FXM_PLATFORM_WINDOWS_
 DLLEXPORT void STDCALL FPDF_RenderPage(HDC dc,
                                        FPDF_PAGE page,
                                        int start_x,


### PR DESCRIPTION
Changed a few ifdefs to allow compiling with qt and windows (MSVC 2017).
Q_CC_MSVC and Q_OS_WIN are only defined when including Qt-Headers.